### PR TITLE
feat: queries to add and remove single or multiple trees

### DIFF
--- a/src/supabase/queries.ts
+++ b/src/supabase/queries.ts
@@ -10,11 +10,10 @@ export async function addTree(species: string) {
 }
 
 // Function to add multiple trees
-export async function addMultipleTrees(
-  trees: { species: string; quantity: number }[],
-) {
+export async function addMultipleTrees(species: string, quantity: number) {
   const { error } = await supabase.rpc('add_multiple_trees', {
-    trees: JSON.stringify(trees),
+    species: species,
+    quantity: quantity,
   });
 
   if (error) {
@@ -36,7 +35,7 @@ export async function removeTree(treeId: string) {
 // Function to remove multiple trees by a list of UUIDs
 export async function removeMultipleTrees(treeIds: string[]) {
   const { error } = await supabase.rpc('remove_multiple_trees', {
-    p_tree_ids: treeIds,
+    tree_uuids: treeIds,
   });
 
   if (error) {

--- a/src/supabase/queries.ts
+++ b/src/supabase/queries.ts
@@ -2,51 +2,44 @@ import { supabase } from './client';
 
 // Function to add a single tree
 export async function addTree(species: string) {
-  const { data, error } = await supabase.rpc('add_tree', { species });
+  const { error } = await supabase.rpc('add_tree', { species });
 
   if (error) {
     throw new Error(`Error adding tree: ${error.message}`);
   }
-
-  return data;
 }
 
 // Function to add multiple trees
-export async function addMultipleTrees(species: string, quantity: number) {
-  const { data, error } = await supabase.rpc('add_multiple_trees', {
-    species,
-    quantity,
+export async function addMultipleTrees(
+  trees: { species: string; quantity: number }[],
+) {
+  const { error } = await supabase.rpc('add_multiple_trees', {
+    trees: JSON.stringify(trees),
   });
 
   if (error) {
     throw new Error(`Error adding multiple trees: ${error.message}`);
   }
-
-  return data;
 }
 
 // Function to remove a single tree by UUID
 export async function removeTree(treeId: string) {
-  const { data, error } = await supabase.rpc('remove_tree', {
-    tree_id: treeId,
+  const { error } = await supabase.rpc('remove_tree', {
+    tree_uuid: treeId,
   });
 
   if (error) {
     throw new Error(`Error removing tree: ${error.message}`);
   }
-
-  return data;
 }
 
 // Function to remove multiple trees by a list of UUIDs
 export async function removeMultipleTrees(treeIds: string[]) {
-  const { data, error } = await supabase.rpc('remove_multiple_trees', {
-    tree_ids: treeIds,
+  const { error } = await supabase.rpc('remove_multiple_trees', {
+    p_tree_ids: treeIds,
   });
 
   if (error) {
     throw new Error(`Error removing multiple trees: ${error.message}`);
   }
-
-  return data;
 }

--- a/src/supabase/queries.ts
+++ b/src/supabase/queries.ts
@@ -1,0 +1,52 @@
+import { supabase } from './client';
+
+// Function to add a single tree
+export async function addTree(species: string) {
+  const { data, error } = await supabase.rpc('add_tree', { species });
+
+  if (error) {
+    throw new Error(`Error adding tree: ${error.message}`);
+  }
+
+  return data;
+}
+
+// Function to add multiple trees
+export async function addMultipleTrees(species: string, quantity: number) {
+  const { data, error } = await supabase.rpc('add_multiple_trees', {
+    species,
+    quantity,
+  });
+
+  if (error) {
+    throw new Error(`Error adding multiple trees: ${error.message}`);
+  }
+
+  return data;
+}
+
+// Function to remove a single tree by UUID
+export async function removeTree(treeId: string) {
+  const { data, error } = await supabase.rpc('remove_tree', {
+    tree_id: treeId,
+  });
+
+  if (error) {
+    throw new Error(`Error removing tree: ${error.message}`);
+  }
+
+  return data;
+}
+
+// Function to remove multiple trees by a list of UUIDs
+export async function removeMultipleTrees(treeIds: string[]) {
+  const { data, error } = await supabase.rpc('remove_multiple_trees', {
+    tree_ids: treeIds,
+  });
+
+  if (error) {
+    throw new Error(`Error removing multiple trees: ${error.message}`);
+  }
+
+  return data;
+}


### PR DESCRIPTION
## What's new in this PR
### Description
Query support for invoking existing Supabase Database Functions for the following actions:
- Add a single tree given a species, using a random uuid and default values for the rest of the properties.
- Add multiple trees given a species and quantity.
- Remove a tree given a uuid.
- Remove multiple trees given a list of uuids.

## How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'

Examine `supabase/queries.ts` and use of `client.ts` for Supabase queries. Check compliance with Linear sprint specs.


## Next steps
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."


## Testing
All queries and Supabase Functions are tested manually, through invoking buttons written to trigger queries in `App.tsx`. Adding single and multiple trees, and removing single and multiple trees (UUID JSON) worked as intended,and is reflected in the database.

## Relevant links
### Online sources
[//]: # 'Copy links to any tutorials or documentation that was useful to you when working on this PR'
N/A

### Related PRs
[//]: # "Add related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"
N/A

CC: @christophertorres1 
