### PR TITLE
Made icons on tree page clickable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "react-native-elements": "^3.4.3",
         "react-native-gesture-handler": "~2.20.2",
         "react-native-paper": "^5.12.5",
+        "react-native-popover-view": "^6.1.0",
         "react-native-reanimated": "~3.16.1",
         "react-native-safe-area-context": "^4.12.0",
         "react-native-screens": "~4.4.0",
@@ -7086,6 +7087,12 @@
         "@babel/core": "*"
       }
     },
+    "node_modules/@react-native/normalize-color": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.1.0.tgz",
+      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA==",
+      "license": "MIT"
+    },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.76.5",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.76.5.tgz",
@@ -10634,6 +10641,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/deprecated-react-native-prop-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz",
+      "integrity": "sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/normalize-color": "*",
+        "invariant": "*",
+        "prop-types": "*"
       }
     },
     "node_modules/destroy": {
@@ -17774,6 +17792,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8"
+      }
+    },
+    "node_modules/react-native-popover-view": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-popover-view/-/react-native-popover-view-6.1.0.tgz",
+      "integrity": "sha512-j1CB+yPwTKlBvIJBNb1AwiHyF/r+W5+AJIbHk79GRa+0z6PVtW4C7NWJWPqUVkCMOcJtewl6Pr6f2dc/87cVyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "deprecated-react-native-prop-types": "^2.3.0",
+        "prop-types": "^15.8.1"
       }
     },
     "node_modules/react-native-ratings": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-native-elements": "^3.4.3",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-paper": "^5.12.5",
+    "react-native-popover-view": "^6.1.0",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "^4.12.0",
     "react-native-screens": "~4.4.0",

--- a/src/components/PropertyIcon/PropertyIcon.tsx
+++ b/src/components/PropertyIcon/PropertyIcon.tsx
@@ -22,8 +22,6 @@ type PropertyIconProps = {
   iconProps?: SvgProps;
 };
 
-
-
 export default function PropertyIcon({
   Icon,
   infoKey,

--- a/src/components/PropertyIcon/PropertyIcon.tsx
+++ b/src/components/PropertyIcon/PropertyIcon.tsx
@@ -22,11 +22,13 @@ type PropertyIconProps = {
   iconProps?: SvgProps;
 };
 
-const PropertyIcon: React.FC<PropertyIconProps> = ({
+
+
+export default function PropertyIcon({
   Icon,
   infoKey,
   iconProps,
-}) => {
+}: PropertyIconProps) {
   const [visible, setVisible] = useState(false);
 
   return (
@@ -40,6 +42,4 @@ const PropertyIcon: React.FC<PropertyIconProps> = ({
       </TouchableOpacity>
     </View>
   );
-};
-
-export default PropertyIcon;
+}

--- a/src/components/PropertyIcon/PropertyIcon.tsx
+++ b/src/components/PropertyIcon/PropertyIcon.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import Popover from 'react-native-popover-view';
+import { SvgProps } from 'react-native-svg';
+
+/*
+const infoMessages: { [key: string]: string } = {
+  height: 'Maximum height',
+  shape: 'Tree shape',
+  water: 'Water usage',
+  root: 'Root damage potential',
+  litter: 'Type of litter',
+  native: 'CA native',
+  foliage: 'Foliage',
+  utility: 'Utility',
+};
+*/
+
+type PropertyIconProps = {
+  Icon: React.FC<SvgProps>;
+  infoKey: string;
+  iconProps?: SvgProps;
+};
+
+const PropertyIcon: React.FC<PropertyIconProps> = ({
+  Icon,
+  infoKey,
+  iconProps,
+}) => {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <View>
+      <Popover isVisible={visible} onRequestClose={() => setVisible(false)}>
+        <Text>This is a tooltip!</Text>
+      </Popover>
+
+      <TouchableOpacity onPress={() => setVisible(true)}>
+        <Icon {...iconProps} />
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default PropertyIcon;

--- a/src/components/SpeciesDisplay/SpeciesDisplay.tsx
+++ b/src/components/SpeciesDisplay/SpeciesDisplay.tsx
@@ -12,12 +12,14 @@ import SvgWarning2 from '@/icons/Warning2';
 import SvgWateringCan from '@/icons/WateringCan';
 import { displayValue, Tree } from '@/types/tree';
 import { TreeSpecies, TreeSpeciesFoliageType } from '@/types/tree_species';
+import PropertyIcon from '../PropertyIcon/PropertyIcon';
 import styles from './styles';
 
 type SpeciesDisplayProps = {
   speciesData: Partial<TreeSpecies>;
   treeData: Tree[];
 };
+
 export default function SpeciesDisplay({
   speciesData,
   treeData,
@@ -49,7 +51,7 @@ export default function SpeciesDisplay({
       <View style={styles.properties}>
         {speciesData.max_height_ft && (
           <View style={styles.property}>
-            <SvgRuler />
+            <PropertyIcon Icon={SvgRuler} infoKey="height" />
             <Text style={styles.propertyText}>
               {speciesData.max_height_ft} ft
             </Text>
@@ -58,7 +60,7 @@ export default function SpeciesDisplay({
 
         {speciesData.tree_shape && (
           <View style={styles.property}>
-            <SvgShapes />
+            <PropertyIcon Icon={SvgShapes} infoKey="shape" />
             <Text style={styles.propertyText}>
               {displayValue(speciesData.tree_shape)}
             </Text>
@@ -67,7 +69,7 @@ export default function SpeciesDisplay({
 
         {speciesData.water_use && (
           <View style={styles.property}>
-            <SvgWateringCan />
+            <PropertyIcon Icon={SvgWateringCan} infoKey="water" />
             <Text style={styles.propertyText}>
               {displayValue(speciesData.water_use)}
             </Text>
@@ -76,7 +78,7 @@ export default function SpeciesDisplay({
 
         {speciesData.root_damage_potential && (
           <View style={styles.property}>
-            <SvgWarning2 />
+            <PropertyIcon Icon={SvgWarning2} infoKey="root" />
             <Text style={styles.propertyText}>
               {displayValue(speciesData.root_damage_potential)}
             </Text>
@@ -85,7 +87,7 @@ export default function SpeciesDisplay({
 
         {speciesData.litter_type && (
           <View style={styles.property}>
-            <SvgFruit />
+            <PropertyIcon Icon={SvgFruit} infoKey="fruit" />
             <Text style={styles.propertyText}>
               {displayValue(speciesData.litter_type)} Fruit
             </Text>
@@ -94,21 +96,21 @@ export default function SpeciesDisplay({
 
         {speciesData.california_native && (
           <View style={styles.property}>
-            <SvgBear />
+            <PropertyIcon Icon={SvgBear} infoKey="native" />
             <Text style={styles.propertyText}>CA Native</Text>
           </View>
         )}
 
         {speciesData.foliage_type === TreeSpeciesFoliageType.Evergreen && (
           <View style={styles.property}>
-            <SvgLeaf />
+            <PropertyIcon Icon={SvgLeaf} infoKey="foliage" />
             <Text style={styles.propertyText}>Evergreen</Text>
           </View>
         )}
 
         {speciesData.utility_friendly && (
           <View style={styles.property}>
-            <SvgFlash />
+            <PropertyIcon Icon={SvgFlash} infoKey="utility" />
             <Text style={styles.propertyText}>Powerline Friendly</Text>
           </View>
         )}
@@ -123,7 +125,7 @@ export default function SpeciesDisplay({
                 style={styles.locationEntry}
                 key={`${tree.bank}-${tree.row}-${index}`}
               >
-                <SvgLocationPin />
+                <PropertyIcon Icon={SvgLocationPin} infoKey="water" />
                 <Text style={styles.propertyText}>
                   Bank #{tree.bank ?? 0} {'  '}|{'  '} Row #{tree.row ?? 0}
                   {/* TODO: Needs to support range of rows */}


### PR DESCRIPTION
## What's new in this PR
### Description

Made the icons on the tree information page clickable. A box will pull up in the middle of the page. 

Made new file - PropertyIcons - and edited Species Display. In species display, the original icons are replaced with a 'PropertyIcon' that allows it to be pressed on and display more information. 

## How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'

1. PropertyIcon (new component)
2. SpeciesDisplay (each icon is now replaced with a new PropertyIcon component)


CC: @christophertorres1 <!-- Include Carys if this PR involves frontend changes -->
