### PR TITLE
feat: add 'any' option to tree shape dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -82,6 +82,8 @@ export const Dropdown = <T extends string[]>({
         onChange={(item: Option) => {
           onChange(item.value);
         }}
+        keyboardAvoiding={true}
+        autoScroll={false}
       />
     </View>
   );

--- a/src/components/SearchFilter/SearchFilter.tsx
+++ b/src/components/SearchFilter/SearchFilter.tsx
@@ -50,6 +50,8 @@ export const SearchFilter: React.FC<SearchFilterProps> = ({
     activeFilters.shape,
   );
 
+  const treeShapeOptions = ['Any', ...Object.values(TreeSpeciesShape)];
+
   const [activeLitterFilters, setActiveLitterFilters] = useState({
     wet: activeFilters.litter.includes('wet'),
     dry: activeFilters.litter.includes('dry'),
@@ -83,7 +85,7 @@ export const SearchFilter: React.FC<SearchFilterProps> = ({
       height: Object.keys(activeHeightFilters).filter(
         key => activeHeightFilters[key as keyof typeof activeHeightFilters],
       ) as string[],
-      shape: selectedTreeShape,
+      shape: selectedTreeShape === 'Any' ? '' : selectedTreeShape,
       litter: Object.keys(activeLitterFilters).filter(
         key => activeLitterFilters[key as keyof typeof activeLitterFilters],
       ) as string[],
@@ -229,8 +231,8 @@ export const SearchFilter: React.FC<SearchFilterProps> = ({
             <View style={styles.filterProperties}>
               <Text style={styles.subheaderText}>Tree Shape</Text>
               <Dropdown
-                options={Object.values(TreeSpeciesShape)}
-                value={selectedTreeShape}
+                options={treeShapeOptions}
+                value={selectedTreeShape || 'Any'}
                 onChange={setSelectedTreeShape}
               />
             </View>


### PR DESCRIPTION
## What's new in this PR
### Description
- Added an 'Any' option to the tree species filter under the 'Tree Shape' dropdown.
- Disabled auto scroll on the dropdown component to prevent scroll jumping.

### Screenshots
![Screenshot 2025-03-15 at 11 52 22 AM](https://github.com/user-attachments/assets/19403847-2880-4345-b0f7-6f4a3ab44dba)

## How to review
Open the filter, select an option and click 'Complete'. Reopen the filter and select 'Any'.

## Next steps
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."



## Relevant links
### Online sources
[//]: # 'Copy links to any tutorials or documentation that was useful to you when working on this PR'



### Related PRs
[//]: # "Add related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"



CC: @christophertorres1 <!-- Include Carys if this PR involves frontend changes -->
