### PR TITLE
feat: type updates, format lists

### DIFF
--- a/src/components/ShrubSpeciesDisplay/styles.ts
+++ b/src/components/ShrubSpeciesDisplay/styles.ts
@@ -62,7 +62,7 @@ export const styles = StyleSheet.create({
   property: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'center',
+    alignItems: 'flex-start',
   },
 
   propertyName: {
@@ -73,5 +73,8 @@ export const styles = StyleSheet.create({
   propertyText: {
     ...typography.mediumRegular,
     color: colors.black1,
+    flexShrink: 1,
+    flexWrap: 'wrap',
+    textAlign: 'right',
   },
 });

--- a/src/components/TreeSearchFilter/TreeSearchFilter.tsx
+++ b/src/components/TreeSearchFilter/TreeSearchFilter.tsx
@@ -61,6 +61,7 @@ export const TreeSearchFilter: React.FC<TreeSearchFilterProps> = ({
   const [activeLitterFilters, setActiveLitterFilters] = useState({
     wet: activeFilters.litter.includes('wet'),
     dry: activeFilters.litter.includes('dry'),
+    none: activeFilters.litter.includes('none'),
   });
 
   const [activeOtherFilters, setActiveOtherFilters] = useState({
@@ -151,6 +152,7 @@ export const TreeSearchFilter: React.FC<TreeSearchFilterProps> = ({
     setActiveLitterFilters({
       wet: false,
       dry: false,
+      none: false,
     });
     setActiveWaterFilters({
       low: false,
@@ -250,6 +252,11 @@ export const TreeSearchFilter: React.FC<TreeSearchFilterProps> = ({
                   label="Dry Fruit"
                   isChecked={activeLitterFilters.dry}
                   onChange={() => toggleLitterFilter('dry')}
+                />
+                <Checkbox
+                  label="No Fruit"
+                  isChecked={activeLitterFilters.none}
+                  onChange={() => toggleLitterFilter('none')}
                 />
               </View>
             </View>

--- a/src/types/shrub_species.ts
+++ b/src/types/shrub_species.ts
@@ -12,7 +12,7 @@ export type ShrubSpecies = {
   bloom: ShrubSpeciesBloomType;
   growth_rate: ShrubSpeciesGrowthType;
   sun_exposure: ShrubSpeciesSunExposure;
-  soil_needs: ShrubSpeciesSoilNeeds;
+  soil_needs: string;
   water_use: ShrubSpeciesWaterUse;
   total_stock: number;
   available_stock: number;
@@ -36,12 +36,7 @@ export enum ShrubSpeciesSunExposure {
   FullSun = 'full sun',
   PartialShade = 'partial shade',
   Shade = 'shade',
-}
-
-export enum ShrubSpeciesSoilNeeds {
-  WellDraining = 'well-draining',
-  Clay = 'clay',
-  CoarseGrained = 'coarse-grained',
+  FullSunPartianShade = 'full_sun_partian_shade',
 }
 
 export enum ShrubSpeciesWaterUse {
@@ -62,7 +57,16 @@ export const toTitleCase = (str: string) =>
     text => text.charAt(0).toUpperCase() + text.substring(1).toLowerCase(),
   );
 
-export const formatEnumKey = (s?: string) => {
-  if (typeof s !== 'string') return '';
-  return s.replace(/_/g, ' ').toLowerCase();
+export const formatEnumKey = (value?: string | string[]) => {
+  if (value === undefined) return '';
+
+  // handle array
+  if (Array.isArray(value)) {
+    return value.map(item => {
+      if (typeof item !== 'string') return '';
+      return item.replace(/_/g, ' ').toLowerCase();
+    });
+  }
+  if (typeof value !== 'string') return '';
+  return value.replace(/_/g, ' ').toLowerCase();
 };

--- a/src/types/shrub_species.ts
+++ b/src/types/shrub_species.ts
@@ -17,7 +17,7 @@ export type ShrubSpecies = {
   total_stock: number;
   available_stock: number;
   image_url?: string;
-  is_low_growing: boolean; // ADDED FOR THE SPRINT, THIS MAY NEED TO BE REMOVED
+  is_low_growing: boolean; 
 };
 
 export enum ShrubSpeciesStemType {
@@ -36,7 +36,7 @@ export enum ShrubSpeciesSunExposure {
   FullSun = 'full sun',
   PartialShade = 'partial shade',
   Shade = 'shade',
-  FullSunPartianShade = 'full_sun_partian_shade',
+  FullSunPartialShade = 'full_sun_partial_shade',
 }
 
 export enum ShrubSpeciesWaterUse {
@@ -59,14 +59,16 @@ export const toTitleCase = (str: string) =>
 
 export const formatEnumKey = (value?: string | string[]) => {
   if (value === undefined) return '';
-
-  // handle array
+  const format = (str: string) => str.replace(/_/g, ' ').toLowerCase();
   if (Array.isArray(value)) {
-    return value.map(item => {
-      if (typeof item !== 'string') return '';
-      return item.replace(/_/g, ' ').toLowerCase();
-    });
+    const formatted = value
+      .filter((item): item is string => typeof item === 'string')
+      .map(format);
+    if (formatted.length === 0) return '';
+    formatted[0] = formatted[0].charAt(0).toUpperCase() + formatted[0].slice(1);
+    return formatted.join(', ');
   }
   if (typeof value !== 'string') return '';
-  return value.replace(/_/g, ' ').toLowerCase();
+  const cleaned = format(value);
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
 };

--- a/src/types/shrub_species.ts
+++ b/src/types/shrub_species.ts
@@ -17,7 +17,7 @@ export type ShrubSpecies = {
   total_stock: number;
   available_stock: number;
   image_url?: string;
-  is_low_growing: boolean; 
+  is_low_growing: boolean;
 };
 
 export enum ShrubSpeciesStemType {

--- a/src/types/tree_species.ts
+++ b/src/types/tree_species.ts
@@ -38,7 +38,7 @@ export enum TreeSpeciesFoliageType {
 export enum TreeSpeciesLitterType {
   Dry = 'dry',
   Wet = 'wet',
-  NoFruit = 'no_fruit',
+  None = 'no',
 }
 
 export enum TreeSpeciesWaterUse {

--- a/src/types/tree_species.ts
+++ b/src/types/tree_species.ts
@@ -22,12 +22,10 @@ export enum TreeSpeciesShape {
   Columnar = 'columnar',
   Conical = 'conical',
   Irregular = 'irregular',
-  Palm = 'palm',
   Rounded = 'rounded',
   Prostrate = 'prostrate',
   Pyramid = 'pyramid',
   Sprawling = 'sprawling',
-  SwordPalm = 'sword_palm',
   Weeping = 'weeping',
   Vase = 'vase',
 }
@@ -40,6 +38,7 @@ export enum TreeSpeciesFoliageType {
 export enum TreeSpeciesLitterType {
   Dry = 'dry',
   Wet = 'wet',
+  NoFruit = 'no_fruit',
 }
 
 export enum TreeSpeciesWaterUse {


### PR DESCRIPTION
## What's new in this PR
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

Implements type updates to the shrub and tree species definitions, along with enhancing the formatEnumKey function to handle both single strings and arrays of strings.

## How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'

First review the enhanced `formatEnumKey` function in `src/types/shrub_species.ts` to ensure it properly handles both string and array inputs.
Check the removal of the `ShrubSpeciesSoilNeeds` enum and the change of `soil_needs` to string type in the ShrubSpecies interface
Verify the tree species enum changes - removal of palm options and addition of no fruit option
Test that existing code using these types and enums still works correctly with the updates

## Next steps
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."



CC: @christophertorres1 <!-- Include Carys if this PR involves frontend changes -->
